### PR TITLE
Update for php 7.2

### DIFF
--- a/src/WizflowManager.php
+++ b/src/WizflowManager.php
@@ -9,7 +9,7 @@ use yii\base\InvalidConfigException;
 /**
  * Implement the Wizard UI design pattern using yii2-workflow.
  */
-class WizflowManager extends \yii\base\Object
+class WizflowManager extends \yii\base\BaseObject
 {
 	/**
 	 * @var array SimpleWorkflowBehavior configuration array attached to all wizard steps


### PR DESCRIPTION
In php 7.2 you cannot use Object class of Yii2 due to confict with the native class Object